### PR TITLE
Add taskforce leadership section to README, add Darius Kazemi as co-chair

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ It is used:
 
 **Note:** we cannot directly change or improve various software that implements ActivityPub within the scope of this Taskforce, for that, please file issues with the respective project's issue trackers, potentially cross referencing issues here.
 
+## Taskforce Leadership
+
+This taskforce is co-chaired by:
+
+- Emelia Smith ([@thisismissem](https://github.com/thisismissem) / [@thisismissem@hachyderm.io](https://hachyderm.io/@thisismissem))
+- Darius Kazemi ([@dariusk](https://github.com/dariusk) / [@darius@friend.camp](https://friend.camp/@darius))
+
+Emelia and Darius are responsible for coordinating and running the taskforce meetings, their primary role is to facilitate consensus-building among taskforce members. For more on what it means to be a chair in the context of W3C related taskforces or groups, see: https://www.w3.org/Guide/chair/role.html
+
 ## Scope of work
 
 The initial scope of work for this task force is split into three workstreams, as follows:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ It is used:
 
 ## Taskforce Leadership
 
-This taskforce is co-chaired by:
+This taskforce is led by:
 
 - Emelia Smith ([@thisismissem](https://github.com/thisismissem) / [@thisismissem@hachyderm.io](https://hachyderm.io/@thisismissem))
 - Darius Kazemi ([@dariusk](https://github.com/dariusk) / [@darius@friend.camp](https://friend.camp/@darius))
 
-Emelia and Darius are responsible for coordinating and running the taskforce meetings, their primary role is to facilitate consensus-building among taskforce members. For more on what it means to be a chair in the context of W3C related taskforces or groups, see: https://www.w3.org/Guide/chair/role.html
+Emelia and Darius are responsible for coordinating and running the taskforce meetings, their primary role is to facilitate consensus-building among taskforce members.
 
 ## Scope of work
 


### PR DESCRIPTION
Originally I hadn't mentioned being the chair of the taskforce in the original README.md, however, I think it's necessary to mention this now.

I've taken the step to add Darius Kazemi (@dariusk) as a co-chair of the taskforce, given his extensive background in Fediverse Trust and Safety and willingness to take on the responsibilities of co-chairing the taskforce. This is also due to me having some health issues of late and not being at 100%, so I'm needing some help with the administration of the taskforce.