### PR TITLE
Add initial fediverse enhancement proposal scaffolding

### DIFF
--- a/feps/README.md
+++ b/feps/README.md
@@ -1,0 +1,7 @@
+## About these FEPs
+
+We'll initially be authoring some Fediverse Enhancement Proposals (FEPs) within the taskforce repository, discussing them and reviewing them, before ultimately opening pull requests against the [FEP repository](https://codeberg.org/fediverse/fep/src/branch/main/) for them.
+
+FEPs proposed here should not be relied upon by developers, as they are a work-in-progress.
+
+To author a FEP in the context of this taskforce, please create a branch and then use the template in `feps/_template.md` to setup the FEP.

--- a/feps/_template.md
+++ b/feps/_template.md
@@ -1,0 +1,33 @@
+---
+slug: "xxxx"
+authors: Alyssa P. Hacker <alyssa.p.hacker@email.example>, Chatty Ben <@ben@fediverse.example>
+status: DRAFT
+dateReceived: 1970-01-01
+discussionsTo: https://forum.example/topics/xxxx
+---
+# FEP-xxxx: TITLE OF YOUR PROPOSAL
+
+<!--
+  When creating the actual FEP pull request, use:
+    ./scripts/new_proposal.py <title of your proposal>
+
+  To create the appropriately named file in the FEP repository.
+ -->
+
+## Summary
+
+<!-- A short summary (no more than 200 words) of the proposal. -->
+
+## References
+
+- Christine Lemmer-Webber, Jessica Tallon, Erin Shepherd, Amy Guy, Evan Prodromou, [ActivityPub], 2018
+- Alyssa P. Hacker, [An example proposal][ABC], 2020
+
+[ActivityPub]: https://www.w3.org/TR/activitypub/
+[ABC]: http://abc.example/abc.html
+
+## Copyright
+
+CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+
+To the extent possible under law, the authors of this Fediverse Enhancement Proposal have waived all copyright and related or neighboring rights to this work.

--- a/feps/labels.md
+++ b/feps/labels.md
@@ -1,0 +1,35 @@
+---
+slug: "xxxx"
+authors: Alyssa P. Hacker <alyssa.p.hacker@email.example>, Chatty Ben <@ben@fediverse.example>
+status: DRAFT
+dateReceived: 1970-01-01
+discussionsTo: https://forum.example/topics/xxxx
+---
+# FEP-xxxx: TITLE OF YOUR PROPOSAL
+
+<!--
+  When creating the actual FEP pull request, use:
+    ./scripts/new_proposal.py <title of your proposal>
+
+  To create the appropriately named file in the FEP repository.
+ -->
+
+## Summary
+
+Labels are used to tag content and actors to allow people on the fediverse to better decide what they do or don't want to see. This FEP introduces a new `Label` object type, as well as a collection for labels.
+
+This FEP does not cover application of labels by third-parties, which is to be covered by a future FEP.
+
+## References
+
+- Christine Lemmer-Webber, Jessica Tallon, Erin Shepherd, Amy Guy, Evan Prodromou, [ActivityPub], 2018
+- Alyssa P. Hacker, [An example proposal][ABC], 2020
+
+[ActivityPub]: https://www.w3.org/TR/activitypub/
+[ABC]: http://abc.example/abc.html
+
+## Copyright
+
+CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+
+To the extent possible under law, the authors of this Fediverse Enhancement Proposal have waived all copyright and related or neighboring rights to this work.


### PR DESCRIPTION
We'll be authoring some FEPs initially within the taskforce and discussing them, before ultimately moving them to a pull request against the [FEP repository](https://codeberg.org/fediverse/fep/src/branch/main/).

I've setup the template for the new Labels FEP that we're working on, there'll also be one on Content Warnings and on Annotations.

Completes #82 

cc @dariusk @trwnh