### PR TITLE
Fix formatting of past meeting minutes

### DIFF
--- a/meetings/2024-11-12-taskforce-meeting.md
+++ b/meetings/2024-11-12-taskforce-meeting.md
@@ -1,4 +1,4 @@
-# ActivityPub Trust and Safety Task Force Meeting
+# 2024-11-12: ActivityPub Trust and Safety Task Force Meeting
 
 ## Attending
 
@@ -6,7 +6,7 @@
 - Evan Prodromou <acct:evanprodromou@socialwebfoundation.org>
 - Julian Lam <@julian@community.nodebb.org>
 - Dan Appelquist <@torgo@mastodon.social> - TAG co-chair & busybody
-- Darius Kazemi <@darius@friend.camp>                   
+- Darius Kazemi <@darius@friend.camp>
 - Andy Piper <@andypiper@macaw.social>
 - Lisa Dusseault <@lisarue@mastodon.geekery.org>
 - Estelle Weyl <@estelle@front-end.social>
@@ -37,7 +37,7 @@ Mailing list notice: https://lists.w3.org/Archives/Public/public-swicg/2024Nov/0
      - content warnings / labeling, as to move away from misusing `summary` on `Note` ( [#1](https://github.com/swicg/activitypub-trust-and-safety/issues/1), [#4](https://github.com/swicg/activitypub-trust-and-safety/issues/4) )
      - define Block activity handling / sending for S2S, currently only defined for C2S ( [#23](https://github.com/swicg/activitypub-trust-and-safety/issues/23) )
      - communicating updates and conversations relating to Flag activities ( [#6](https://github.com/swicg/activitypub-trust-and-safety/issues/6), [#7](https://github.com/swicg/activitypub-trust-and-safety/issues/7) )
-     - Explicitly out of scope, but we can include a recommendation in our report(s) about these if necessary: 
+     - Explicitly out of scope, but we can include a recommendation in our report(s) about these if necessary:
        - federation management, i.e., FediBlock, since "instances" are not a thing in ActivityPub, but just a side-effect of S2S.
        - quote posts (has [existing FEPs](https://socialhub.activitypub.rocks/t/disambiguating-various-interpretations-of-a-quote-feature-pre-fep/3426))
        - reply controls (has existing FEPs / implementations - [FEP-7458](https://codeberg.org/fediverse/fep/src/branch/main/fep/7458/fep-7458.md), [reply control discussions](https://socialhub.activitypub.rocks/t/fep-5624-per-object-reply-control-policies/2723))
@@ -58,7 +58,7 @@ Introductions from the above people.
 
 **RESOLVED:** 5pm CET Tuesdays (the time of this meeting) is OK for recurring meetings.
 
-Evan reminded participants to use GitHub to help folks who have to participate asynchronously may do so. 
+Evan reminded participants to use GitHub to help folks who have to participate asynchronously may do so.
 Staging process will be to be followed: https://github.com/swicg/potential-charters/blob/main/stage-process.md
 
 **Proposal:** Meeting cadence every two weeks (same time)
@@ -69,10 +69,10 @@ Staging process will be to be followed: https://github.com/swicg/potential-chart
 
 ### Discussion of Scope
 
-Evan asked about bundling things in the scope together?  Emelia explained that Trust and Safety can have requirements on a number of documents, many of which might not be "owned" by the Trust and Safety TF.  E.g. Reply-control is being defined elsewhere but we can make recommendations to implementors about it. Similarly we aren't defining the S2S HTTP message signatures, but we can make a recommendation to use that.  
+Evan asked about bundling things in the scope together?  Emelia explained that Trust and Safety can have requirements on a number of documents, many of which might not be "owned" by the Trust and Safety TF.  E.g. Reply-control is being defined elsewhere but we can make recommendations to implementors about it. Similarly we aren't defining the S2S HTTP message signatures, but we can make a recommendation to use that.
 
 The scope proposed (in the agenda and at the link in the agenda) is roughly in priority order or order of work. The Flag mechanisms are somewhat under-specified.  We can improve those mechanisms.  Some examples:
- * Mastodon only accepted 500 characters in a report text, but misskey can send ~4000, this lead to interoperability issues (and has since been fixed).  
+ * Mastodon only accepted 500 characters in a report text, but misskey can send ~4000, this lead to interoperability issues (and has since been fixed).
  * Mastodon expects Actor in the list of `objects` in a Flag Activity, although the spec doesn't requiring that, so Flags without the actor in the `objects` list get dropped.
 
 Dan: something that might be useful, in the TAG we've been developing the [privacy principles documentd](
@@ -82,12 +82,12 @@ Emelia: we need some idea of where to send reports as well. right now we send th
 
 Darius agreed with this and pointed to https://fediverse-governance.github.io/#9.-tooling-recommendations for research findings relevant to these goals.
 
-Content warnings and labeling is a whole interesting area; we'd probably like to be able to label posts as containing adult content or violence.  Standard labels that others can reference can help others in the fediverse handle that content appropriately. 
+Content warnings and labeling is a whole interesting area; we'd probably like to be able to label posts as containing adult content or violence.  Standard labels that others can reference can help others in the fediverse handle that content appropriately.
 
 Block activity handling isn't very well specified.  Does the blocked user's server get a Block activity?  We should define what we expect the behavior to be in the S2S part of the flow.
 
 Evan in chat: Block is defined as a SHOULD NOT for delivery. https://www.w3.org/TR/activitypub/#block-activity-outbox
-Yet some implementations do deliver Blocks. 
+Yet some implementations do deliver Blocks.
 
 Communication about flag activity: should there be any way to reply to somebody who makes a report to reply - for acknowledgement, for requesting clarification, or for communicating outcomes?  There's not good communication between moderation teams, which results in friction.  Domains have been fediblocked due to poor communication about moderation activities already.
 
@@ -95,7 +95,7 @@ Darius: [research-based recommendations from me on communication around blocks/f
 
 Emelia: Now for the items I think should be outside of the scope of work for the taskforce initially:
 
-Emelia: Quote posts and reply controls are very much wanted by folks in the Fediverse.  There is an implementation of reply controls and a few people are trying to get a FEP started.  There are 4 different ways of doing quote posts (misskey way, fedibird way, object links, and mastodon approach)  Each of these approaches have safety and privacy concerns about them. This Task Force wouldn't necessarily be defining these mechanisms but can help the groups defining these think through the T&S considerations. 
+Emelia: Quote posts and reply controls are very much wanted by folks in the Fediverse.  There is an implementation of reply controls and a few people are trying to get a FEP started.  There are 4 different ways of doing quote posts (misskey way, fedibird way, object links, and mastodon approach)  Each of these approaches have safety and privacy concerns about them. This Task Force wouldn't necessarily be defining these mechanisms but can help the groups defining these think through the T&S considerations.
 
 (Chat provided some additional links: https://w3id.org/fep/7458, https://socialhub.activitypub.rocks/t/fep-5624-per-object-reply-control-policies/2723 )
 
@@ -113,7 +113,7 @@ Dan Appelquist says: suggest talking about the.g. "Tackling issues that improve 
 
 Emelia: Are there additional areas we should look at?
 
-Evan: maybe look into automatic detection for spam or keywords? ML models, etc. that can help surface problematic content. Something potentially useful to investigate.  Trust & safety can also consider the effectiveness of systems that don't entirely rely on human judgement and when it's a good idea to have a human in the loop.  
+Evan: maybe look into automatic detection for spam or keywords? ML models, etc. that can help surface problematic content. Something potentially useful to investigate.  Trust & safety can also consider the effectiveness of systems that don't entirely rely on human judgement and when it's a good idea to have a human in the loop.
 
 Emelia: As an example of more automated detection, [IFTAS CCS](https://about.iftas.org/activities/moderation-as-a-service/content-classification-service/) does PhotoDNA and automatic filing of reports with [NCMEC](https://www.missingkids.org/home), and can be extended to include NCII and TVEC classification.
 
@@ -121,7 +121,7 @@ Emelia: Some naive Bayes filtering "spam or ham", there is a project working on 
 
 Emelia: We should also have humans involved to make final decisions. For majority of fediverse, the human touch makes a difference in how we moderate our communities. Be very careful with overly algorithmic applications because that creates its own trust and safety issues. For example a model going awry can cut off people from their entire network of communication.
 
-Wes: I think there is possibly a complementary interaction between proactive (automatic) and reactive (flagging, human-based) moderaton that could be well specified. 
+Wes: I think there is possibly a complementary interaction between proactive (automatic) and reactive (flagging, human-based) moderaton that could be well specified.
 
 Wes: Transparency is key. You want to know what is done by a human and what is done by an automated process.
 

--- a/meetings/2025-04-15-taskforce-meeting.md
+++ b/meetings/2025-04-15-taskforce-meeting.md
@@ -1,4 +1,6 @@
-Agenda:
+# 2025-04-15: ActivityPub Trust and Safety Task Force Meeting
+
+## Agenda:
 
 1. IP Protection Note Reminder:
     - Anyone can participate in these calls. However, all substantive contributors to any Taskforce Work Items must be members of the Social Web CG with full IPR agreements signed. https://www.w3.org/community/socialcg/join
@@ -16,6 +18,15 @@ Agenda:
 We support contributions to the Agenda, please comment if there is something that we need to address during the meeting.
 
 You can find information on how to join the meeting in the [SWICG calendar](https://www.w3.org/events/meetings/a54ae3c9-89bc-4bb1-b9db-e9494d2100e1/20250121T110000/)
+
+## Attending
+- Emelia Smith, @thisismissem@hachyderm.io
+- Claire (Mastodon)
+- Echo (Mastodon)
+- Lisa Dusseault <@lisarue@mastodon.geekery.org>
+- a <trwnh.com>
+- Bob
+- Angus
 
 ## Meeting Notes
 
@@ -35,18 +46,18 @@ a: does this matter per se? annotations can be made by anyone 1st/2nd/3rd party;
   - how are you discovering the annotation? fetch the Note and maybe it references an Annotation, or maybe there's an anno provider you trust.
   - is the annotation authorized / do you care to see it? if it's from the author then sure, if it's from the service then you need to signal that there is a service responsible for hosting this Note/Person, if it's an unrelated entity entirely then... well, it comes back to trust again.
 
-Bob's position: We shouldn't invent something new when we have Web Annotations, which we can use as a general mechanism - rather than have custom approaches for each of the things we're trying to do with labels and content warnings. 
+Bob's position: We shouldn't invent something new when we have Web Annotations, which we can use as a general mechanism - rather than have custom approaches for each of the things we're trying to do with labels and content warnings.
 
-Emelia points out that fetching content and then fetching and analysing a collection of annotations to see which ones are authoritative and whether any of them hold a content warning - before even posting a content warning - could cause delay in showing the note.  
+Emelia points out that fetching content and then fetching and analysing a collection of annotations to see which ones are authoritative and whether any of them hold a content warning - before even posting a content warning - could cause delay in showing the note.
 
 Angus: it's attractive not to invent multiple mechanisms for different things... perhaps you could also directly embed an annotation?
 - a: you can!
 
 Lisa: It depends how simple a solution for label and content warnings can be.  It could be much simpler than implementing Web Annotations for ActivityPub - which I point out is rather undefined, we've already talked about several very different approaches.  Implementing a simple solution for content warnings does not preclude doing Web Annotations later.
 
-Bob: DOing the simple thing now and the right thing later...well often later never comes.  If we were to invent ActivityPub now we'd not just add these extra fields - we'd have an abstract model of objects, some of which are annotations of different types. 
+Bob: DOing the simple thing now and the right thing later...well often later never comes.  If we were to invent ActivityPub now we'd not just add these extra fields - we'd have an abstract model of objects, some of which are annotations of different types.
 
-Emelia: Bob would you be interested in writing how to integrate ActivityPub and Web Annotations? 
+Emelia: Bob would you be interested in writing how to integrate ActivityPub and Web Annotations?
 
 Bob: I'm not actually interested in adding Web annotations to ActivityPub. It's to provide annotations. If W3C annotations had become widely popular my opinion might be different.  I imagine how Web annotations actually becomes popular is by its attachment to ActivityPub. We should generate a profile of Web annotations to say what parts of it we use. We may differ from some parts of that spec - it doesn't require us to use it.  But it's wise to reuse.
 
@@ -54,7 +65,7 @@ Emelia:  The concept of annotations in T&S has been undefined.  Maybe we kind of
 
 Bob: We do have content warnings, IMPROPERLY, in the summary field.
 
-Emelia: We do need to describe something such that content warnings stop using the summary field and we can use the summary field for its purpose.  If we decide to move content warnings to use the WEb annotations model, we then have to work to define all the integration questions between two different models/protocols. 
+Emelia: We do need to describe something such that content warnings stop using the summary field and we can use the summary field for its purpose.  If we decide to move content warnings to use the WEb annotations model, we then have to work to define all the integration questions between two different models/protocols.
 
 Angus: What's our specific use case?
 
@@ -64,23 +75,23 @@ Claire: Content warnings could be annotations but are not necessarily so. In Mas
 
 a: i think labels could be tags, but content warnings make sense to be annotations, either directly as a freeform text property or indirectly by pointing to an Annotation with oa:hasBody
 
-a: the publisher (1st/2nd parties) can easily embed whatever property / resource they want... the challenge is only for 3rd party discovery 
+a: the publisher (1st/2nd parties) can easily embed whatever property / resource they want... the challenge is only for 3rd party discovery
 
-Bob: Why wouldn't we allow anyone to annotate a Note with a content warning. Something which is not NSFW in your area might be NSFW in mine. Shouldn't I be able to make that statement and shouldn't people who trust me be able to act on my content warnings? 
+Bob: Why wouldn't we allow anyone to annotate a Note with a content warning. Something which is not NSFW in your area might be NSFW in mine. Shouldn't I be able to make that statement and shouldn't people who trust me be able to act on my content warnings?
 
 Emelia: Possibly, but when the publisher states something that can be displayed differently by clients and user agents. I don't see any way of doing claim review (schema.org) in WEb annotations. Also where do you send it to and where do you fetch it from? I don't see how to do claim review with Web annotations because it attaches to a phrase, not a URI.
 
 Emelia: Yes "NSFW" can be interpreted differently in different places.  Nevertheless, the user has an important opinion about their content.
 
-Claire: A time when you want to add something like "NSFW" to somebody else's post, is in quote posts - quote posts themselves can have content warnings about the thing you quote.  This doesn't mean you SHOULD NOT have content warnings on somebody else's post, but it's not clear how it would work if you have a collection of annotations for everyone. 
+Claire: A time when you want to add something like "NSFW" to somebody else's post, is in quote posts - quote posts themselves can have content warnings about the thing you quote.  This doesn't mean you SHOULD NOT have content warnings on somebody else's post, but it's not clear how it would work if you have a collection of annotations for everyone.
 
 a: maybe we can draw up explicit user stories for this? "alice is a moderator and wants to let observers know that bob was banned for this post" is one such use case, "bob is making a post and wants to let people know before reading it that the post content deals with us politics"
 
-Emelia: The Web annotations work has an assumption of sending annotations TO the publishing server. That's not what you want in a T&S context, where you want authoritative sources.  When a "COVID misinformation" warning is posted about a post, you don't want that to disappear just because the author disagrees. Where you store 3rd party annotations is a crucial point here. 
+Emelia: The Web annotations work has an assumption of sending annotations TO the publishing server. That's not what you want in a T&S context, where you want authoritative sources.  When a "COVID misinformation" warning is posted about a post, you don't want that to disappear just because the author disagrees. Where you store 3rd party annotations is a crucial point here.
 
-Bob: No. Web Annotations allows you to say where you want the annotations to be stored, but it doesn't require that you store them there. It is simply a mechanism to advertise one location for annotations. 
+Bob: No. Web Annotations allows you to say where you want the annotations to be stored, but it doesn't require that you store them there. It is simply a mechanism to advertise one location for annotations.
 
-Emelia: Yes, WEb annotations can be stored in different places and advertised where, which is what we'd have to specify if we went in this direction.  In the case of content warnings, we have well-formed proposals already; very similar to what already works, and it gets us a little step forward. 
+Emelia: Yes, WEb annotations can be stored in different places and advertised where, which is what we'd have to specify if we went in this direction.  In the case of content warnings, we have well-formed proposals already; very similar to what already works, and it gets us a little step forward.
 
 Bob: Having the author of the content tell you where annotations should be stored, solves a problem of the WEb, (audio drops)
 

--- a/meetings/2025-05-13-taskforce-meeting.md
+++ b/meetings/2025-05-13-taskforce-meeting.md
@@ -1,3 +1,5 @@
+# 2025-05-13: ActivityPub Trust and Safety Task Force Meeting
+
 ## Agenda:
 
 1. IP Protection Note Reminder:
@@ -27,27 +29,27 @@ You can find information on how to join the meeting in the [SWICG calendar](http
 - Emelia: yes, there was one voice strongly stating that the data model should be used for content warnings, content labels, and content annotations. The theory is that web annotations works for all these purposes but when I ask for anyone to show use cases where it applies, I am left without an example.
 - Darius: web annotations was designed for annotating documents on the web via a browser.
 - Emelia: yes, it contains things like ways to specify text ranges on a document.
-- Emelia: I think there is a difference between a content warning and a content annotation. A warning has specific user interactions desired as the outcome of it vs an annotation. Something like Community Notes for an annotation is "you see the post still but here is text provided by another user". 
+- Emelia: I think there is a difference between a content warning and a content annotation. A warning has specific user interactions desired as the outcome of it vs an annotation. Something like Community Notes for an annotation is "you see the post still but here is text provided by another user".
 - Jaz: it seems to me that a content warning is just a label applied generally by the author. I've seen people ask for the ability to post hoc add content warnings. I think the data model could and maybe should be separate from the client action. And different clients can do different things with different labels and sources of labels.
 - Darius: what is, data-wise, the difference between content warnings and labels/annotations?
 - Emelia: Content warnings are free text. For labels, there would be something like a label vocabulary that is standardized.
 - Darius: so content warnings would be text in a field; labels would be Objects that can be referenced and embedded in other contexts.
-- a: so would "label" = "structured linked data reference", while "warning" = "unstructured freeform text"? 
-- Jaz: this sounds like we are formalizing the user experience we've observed for content warnings on mastodon, which I find unfit for purpose. The fact that one platform does something with collapsing... a well structured model for this stuff would allow for new emergent activites based on the data. I tentatively agree that a preference would be for vocabularies to exist that clients could make use of to help labeling and warning, but I am itching at the thought that we are formalizing an observed experience from one microblogging software. Instead of trying to put formality around the thing we see and the way it's seen in certain clients, if we unravel and rewind that and think about it from an agnostic perspective we can come up with a way to provide developers ways to come up with what they need while giving audiences more freedom too. 
+- a: so would "label" = "structured linked data reference", while "warning" = "unstructured freeform text"?
+- Jaz: this sounds like we are formalizing the user experience we've observed for content warnings on mastodon, which I find unfit for purpose. The fact that one platform does something with collapsing... a well structured model for this stuff would allow for new emergent activites based on the data. I tentatively agree that a preference would be for vocabularies to exist that clients could make use of to help labeling and warning, but I am itching at the thought that we are formalizing an observed experience from one microblogging software. Instead of trying to put formality around the thing we see and the way it's seen in certain clients, if we unravel and rewind that and think about it from an agnostic perspective we can come up with a way to provide developers ways to come up with what they need while giving audiences more freedom too.
 - Darius: I largely agree with Jaz. How does this work in ATProto with content labelers?
-- Jaz: You bring your own vocabulary, and the PDS can apply some number of actions... hide, blur, warn, maybe some other things. Labeler A can say "depiction of war" and "blur" and Labeler B can say "war images" and "hide". 
-- Emelia: https://docs.joinmastodon.org/entities/Filter/#filter_action mastodon now has the same three actions with content filtering 
+- Jaz: You bring your own vocabulary, and the PDS can apply some number of actions... hide, blur, warn, maybe some other things. Labeler A can say "depiction of war" and "blur" and Labeler B can say "war images" and "hide".
+- Emelia: https://docs.joinmastodon.org/entities/Filter/#filter_action mastodon now has the same three actions with content filtering
 - Emelia: the difference between a label and content warning is the former is structured linked data that can be referenced, latter is unstrutured freeform text. For labels you have structured labels, but I'm not saying there should be one vocabulary but many vocabularies. Bluesky has a base set of labels that they have defined, Mastodon would probably also want to have theirs.
 - Darius: so a vocabulary should be an Unordered Collection of Label objects.
 - Emelia: yes, you can see it in FIRES: https://fires.fedimod.org/reference/protocol/labels.html
 - Emelia: I don't want us to be defining the labels. Just how you define the labels and share them, and how you associate a label with an object in the AP spec. You could cram all this into web annotations but I don't think that makes sense because we would be extending the web annotations vocabulary anyway since it doesn't have a notion of labels.
-- a: What if there are two labels, one says "war" and one says "depiction of war"? Who gets to decide two labels are the same thing? Maybe we have a two-tier system where a label publisher can suggest that their label is a subclass or equivalent label. 
+- a: What if there are two labels, one says "war" and one says "depiction of war"? Who gets to decide two labels are the same thing? Maybe we have a two-tier system where a label publisher can suggest that their label is a subclass or equivalent label.
 - Jaz: no one really finds equivalences in that ecosystem. It's more just a choice of who people subscribe to.
 - Emelia: right, we want to avoid string matching any more.
 - Jaz: why don't we just adopt what is on the FIRES link you posted?
 - Emelia: https://github.com/fedimod/fires/issues/68 issue on specifying recommended actions on content
 - Darius: do we need to specify actions as objects?
-- denny:  I don't see why specifying the action is within the ambit of a labeler's job. Wouldn't have occured to me as an application developer to look for action information in the label object. 
+- denny:  I don't see why specifying the action is within the ambit of a labeler's job. Wouldn't have occured to me as an application developer to look for action information in the label object.
 - Emelia: I think you make it a string and we specify a set of starter strings
 - Darius: are we reinventing mime-types here?
 - Emelia: maybe we publish a repository of possible actions?
@@ -71,15 +73,15 @@ You can find information on how to join the meeting in the [SWICG calendar](http
 - Jaz: why can't I personally write a `summary` of "Trigger warning: content includes blah" -- I use Trigger warning specifically because that's different from CW.
 - Emelia: if we say `summary` is that, and then labels actually drive content warnings, how do you have software indicate "the author meant this as a CW" vs "the author meant to collapse".
 - a: for collapsing, there's the `sensitive` property. Mastodon doesn't distinguish between `summary` and `sensitive`
-- Jaz: let's take this out of mastodon and into a blog. What if a blog author writes warnings into the top of the post. That's fine. Let's have free text and have it not mean anything other than it's free text. We don't need a separate property for content warnings. 
+- Jaz: let's take this out of mastodon and into a blog. What if a blog author writes warnings into the top of the post. That's fine. Let's have free text and have it not mean anything other than it's free text. We don't need a separate property for content warnings.
 - Emelia: So perhaps expected behavior is: summary is free text; sensitive tells people whether things are collapsed or not; labels can be interpreted separately.
-- a: i still think that `summary` can be correct even for content warnings, it's more about how much do we want to be able to signal the purpose of it? in AS2 it is defined as a "summary" in the sense that a plaintext representation of an object would have it be the secondary bit next to the name/title 
+- a: i still think that `summary` can be correct even for content warnings, it's more about how much do we want to be able to signal the purpose of it? in AS2 it is defined as a "summary" in the sense that a plaintext representation of an object would have it be the secondary bit next to the name/title
 - Jaz: I have found `sensitive` to be nonsense. maybe we just have it all be labels
 - Darius: seems like `sensitive` is an example of the phase 2 "here is a recommended action"
 - Jaz: with structured labels we are going to want actions.
 - Jaz: can I get clarity. Emelia I think this is your contention, I am looking at FIRES labels. I think I understand that you won't or can't ascribe an Actor to the Activity of labeling a thing. I'm trying to wrap my head around how we do a spec where we talk about label discovery and representation but we don't add in who is responsible for applying labels.
 - Emelia: we could add `attributedTo`. In the case of FIRES I don't need it because the label _is_ the provider of the label but for a more generic case we could.
-- a: https://www.w3.org/TR/annotation-model/#motivation-and-purpose a Label could also extend from an Annotation, it can be multiple things depending on the properties you want it to have 
+- a: https://www.w3.org/TR/annotation-model/#motivation-and-purpose a Label could also extend from an Annotation, it can be multiple things depending on the properties you want it to have
 
 ## Outcomes
 

--- a/meetings/2025-05-27-taskforce-meeting.md
+++ b/meetings/2025-05-27-taskforce-meeting.md
@@ -1,3 +1,5 @@
+# 2025-05-27: ActivityPub Trust and Safety Task Force Meeting
+
 ### Agenda:
 
 1. IP Protection Note Reminder:
@@ -14,16 +16,17 @@ We support contributions to the Agenda, please comment if there is something tha
 You can find information on how to join the meeting in the [SWICG calendar](https://www.w3.org/events/meetings/a54ae3c9-89bc-4bb1-b9db-e9494d2100e1/20250121T110000/)
 
 ### Attendance
-    - Jaz
-    - Emelia (partially)
-    - Darius
-    - Lisa
-    - Julian
+
+- Jaz
+- Emelia (partially)
+- Darius
+- Lisa
+- Julian
 
 ### Notes
 
 - Emelia: Just a quick note that sometimes I won't be available for meetings, or won't be fully focused during them, as I've some health issues that lead to significant fatigue and spontaneous coughing fits. In my abscence, please do continue to discuss issues or file new isssues, and take meeting notes (you can use hackmd and open a pull request with them, or drop the link to them to Emelia via email: emelia@brandedcode.com).
-- Julian: next Forums/Discussion TF meeting, talking about the idea of having one reply tree across multiple communities and multiple categories. Who "owns" a tree when cross posting? Is it the author, is anyone, something else? Early discussions right now around writing a FEP. Many implementations have reply controls of some kind or another. 
+- Julian: next Forums/Discussion TF meeting, talking about the idea of having one reply tree across multiple communities and multiple categories. Who "owns" a tree when cross posting? Is it the author, is anyone, something else? Early discussions right now around writing a FEP. Many implementations have reply controls of some kind or another.
 - Julian: Mastodon FASPs for discovery... T&S thoughts?
     - Emelia: the FASP protocol is that only object IDs of activities are sent to the FASP, and then the FASP has to request those like an ActivityPub server would. From a user's perspective they can domain block a FASP if they want. The FASP is opt-in on a server administrator level, like a relay. FASPs are required to have terms of service and data sharing policies, and the UI might give you a snippet you can paste into your own Terms of Service when you subscribe to a FASP. Currently the only FASP that exists is a user discovery one. The FASP protocol already implements the latest version of HTTP message signatures RFC-9421. It will eventually be extended to do say T&S or media processing etc.
     - https://github.com/mastodon/fediverse_auxiliary_service_provider_specifications/


### PR DESCRIPTION
This just adds the title to the document, and the missing attendance list for one of the meetings.