### PR TITLE
July 22 2025 meeting minutes

### DIFF
--- a/meetings/2025-07-22-taskforce-meeting.md
+++ b/meetings/2025-07-22-taskforce-meeting.md
@@ -1,0 +1,3 @@
+## 2025-07-22: ActivityPub Trust and Safety Task Force Meeting
+
+Note: meeting was adjourned by Darius Kazemi due to lack of attendance.


### PR DESCRIPTION
Simple meeting minutes stub for the July 22 2025 meeting; meeting was adjourned due to lack of attendance. (I am choosing to put in empty minutes with a note so there isn't confusion over whether there are missing minutes.)