### PR TITLE
Add NLNet grant application for ActivityPub Taskforce

### DIFF
--- a/documents/2025-11-26-nlnet-grant-application.md
+++ b/documents/2025-11-26-nlnet-grant-application.md
@@ -1,0 +1,49 @@
+# 2025-11-26: NLNet Grant Application
+
+| Field            | Answer  |
+|------------------|-------------------------------------------------|
+| Applicant name   | Emelia Smith |
+| Project name     | ActivityPub Trust & Safety Taskforce |
+| Fund             | Open_Call |
+| Requested amount | € 25000 |
+| Website          | https://github.com/swicg/activitypub-trust-and-safety/ |
+| Submission Date  | 2025-11-26 |
+
+## Synopsis
+
+The ActivityPub Trust & Safety Taskforce is working to improve the trust and safety for projects built on the ActivityPub protocol. The taskforce has now been operating for about 1.5 years (September 2024), and funding will enable quicker progress on various work areas including:
+
+- Content-labeling for the fediverse (both self-labeling and third-party labeling, like on Bluesky)
+- Moderation actor discovery (so reports can be correctly routed)
+- Categorisation of reports (allowing servers to define what categories of issue that can be reported to them)
+- Discussion on moderation reports between ActivityPub servers.
+- Annotations on content (for example community notes for misinformation)
+- Report on Best Practices for ActivityPub Imolementers
+
+## Experience
+
+I'm the founder and co-lead of the taskforce, where I've been coordinating what specifications and documents to develop to improve trust and safety on the fediverse.
+
+## Usage
+
+The budget will be used to fund members of the taskforce to write the specification and report documents, which usually require significant time investment. Each of the above mentioned work areas require one or more FEP documents to be written, or a WBC Report to be written.
+
+Additionally, I'd like to allocate funds to the management of the taskforce meetings, and hiring a scribe for the meetings (as the lack of a dedicated scribe has caused communication issues).
+
+Whilst Emelia Smith is the applicant for this grant, there will be multiple people from the taskforce as the recipients of funds. The idea would be to allocate funds to each work area and then allow people to volunteer to work on those projects and be paid for their time.
+
+## Comparison
+
+There hasn't really been historical efforts on this, which has lead to the Fediverse lagging behind in trust and safety capabilities.
+
+## Challenges
+
+Each of the specifications may have their own technical challenges to solve.
+
+## Ecosystem
+
+This will involve the ActivityPub Trust and Safety Taskforce members, and working with Fediverse software developers to ensure the specifications meet requirements.
+
+---
+
+There were no additional attachments, since there isn't really anything else to say.


### PR DESCRIPTION
This document outlines the submitted NLNet grant application for the ActivityPub Trust & Safety Taskforce, detailing the project goals, budget allocation, and challenges.

Completes #102 for now.