### PR TITLE
Add attendees section to meeting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting-template.md
+++ b/.github/ISSUE_TEMPLATE/meeting-template.md
@@ -10,7 +10,7 @@ assignees: ''
 ## Attendees
 Please specify your name or pseudonym, affiliation if any, and pronouns, as this will help us take accurate meeting notes.
 
-- (to be filled out during the meeting)
+- (to be filled out during the meeting, also indicate if scribing)
 
 ## Administrivia:
 

--- a/.github/ISSUE_TEMPLATE/meeting-template.md
+++ b/.github/ISSUE_TEMPLATE/meeting-template.md
@@ -7,6 +7,10 @@ assignees: ''
 
 ---
 
+## Attendees
+Please specific your name or pseudonym, affiliation if any, and pronouns, as this will help us take accurate meeting notes.
+
+- (to be filled out during the meeting)
 
 ## Administrivia:
 

--- a/.github/ISSUE_TEMPLATE/meeting-template.md
+++ b/.github/ISSUE_TEMPLATE/meeting-template.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 ## Attendees
-Please specific your name or pseudonym, affiliation if any, and pronouns, as this will help us take accurate meeting notes.
+Please specify your name or pseudonym, affiliation if any, and pronouns, as this will help us take accurate meeting notes.
 
 - (to be filled out during the meeting)
 


### PR DESCRIPTION
Added section for attendees to specify their name, affiliation, and pronouns.

This will avoid awkward cases of misgendering when we have new members joining or AI transcribing the meeting minutes.